### PR TITLE
Fixed Class Name Typo

### DIFF
--- a/Scripts/PlayableShaderGlobalTrack.cs
+++ b/Scripts/PlayableShaderGlobalTrack.cs
@@ -9,7 +9,7 @@ namespace PlayableShaderGlobal
    [TrackColor(0.5f, 0.5f, 0.8f)]
    [TrackMediaType(TimelineAsset.MediaType.Script)]
    [TrackClipType(typeof(PlayableShaderGlobalClip))]
-   public class PlayerShaderGlobalTrack : TrackAsset
+   public class PlayableShaderGlobalTrack : TrackAsset
    {
 
       public override Playable CreateTrackMixer(PlayableGraph graph, GameObject go, int inputCount)


### PR DESCRIPTION
Within the `PlayableShaderGlobalTrack.cs` file the class name was set to `PlayerShaderGlobalTrack` when it should be `PlayableShaderGlobalTrack`.

This fixes a bug where Unity fails to find the right mono script to assign to a new track in TImeline.